### PR TITLE
fix: 修复图片管理面板按钮溢出问题

### DIFF
--- a/src/components/write/components/sections/images-section.tsx
+++ b/src/components/write/components/sections/images-section.tsx
@@ -25,12 +25,12 @@ export function ImagesSection({ delay = 0 }: ImagesSectionProps) {
 				<input
 					type='text'
 					placeholder='https://...'
-					className='input input-bordered input-sm flex-1 bg-base-100 focus:input-primary'
+					className='input input-bordered input-sm flex-1 min-w-0 bg-base-100 focus:input-primary'
 					value={urlInput}
 					onChange={e => setUrlInput(e.target.value)}
 				/>
 				<button
-					className='btn btn-sm btn-ghost border-base-300'
+					className='btn btn-sm btn-ghost border-base-300 shrink-0'
 					onClick={() => {
 						const v = urlInput.trim()
 						if (!v) return


### PR DESCRIPTION
## 修复内容

修复写作页面图片管理面板中按钮溢出容器的问题。

## 修改

- 给添加按钮增加 shrink-0，避免按钮被压缩
- 给输入框增加 min-w-0，使其在窄布局下正常收缩

Fixes #37